### PR TITLE
Fixed timeout bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,6 +144,6 @@ def sadtalker_demo():
 if __name__ == "__main__":
 
     demo = sadtalker_demo()
-    demo.launch(share=True)
+    demo.queue().launch(share=True)
 
 


### PR DESCRIPTION
- Enabling the queue is required for inference times > 60 seconds as mentioned here:
https://github.com/gradio-app/gradio/issues/3185#issuecomment-1428042014