### PR TITLE
Add generator function for face_enhancer to save RAM

### DIFF
--- a/src/facerender/animate.py
+++ b/src/facerender/animate.py
@@ -19,7 +19,7 @@ from src.facerender.modules.generator import OcclusionAwareGenerator, OcclusionA
 from src.facerender.modules.make_animation import make_animation 
 
 from pydub import AudioSegment 
-from src.utils.face_enhancer import enhancer as face_enhancer
+from src.utils.face_enhancer import enhancer_generator_with_len as face_enhancer
 from src.utils.paste_pic import paste_pic
 from src.utils.videoio import save_video_with_watermark
 
@@ -204,9 +204,9 @@ class AnimateFromCoeff():
             enhanced_path = os.path.join(video_save_dir, 'temp_'+video_name_enhancer)
             av_path_enhancer = os.path.join(video_save_dir, video_name_enhancer) 
             return_path = av_path_enhancer
-            enhanced_images = face_enhancer(full_video_path, method=enhancer, bg_upsampler=background_enhancer)
+            enhanced_images_gen_with_len = face_enhancer(full_video_path, method=enhancer, bg_upsampler=background_enhancer)
 
-            imageio.mimsave(enhanced_path, enhanced_images, fps=float(25))
+            imageio.mimsave(enhanced_path, enhanced_images_gen_with_len, fps=float(25))
             
             save_video_with_watermark(enhanced_path, new_audio_path, av_path_enhancer, watermark= False)
             print(f'The generated video is named {video_save_dir}/{video_name_enhancer}')


### PR DESCRIPTION
This PR implements a generator function version of face_enhancer to save RAM by allowing for enhancing and saving images one at a time instead of storing them all in memory. This works because `imageio.mimsave` can work with any iterable as long as the iterable has a `__len__` method. The original `enhancer` function works as before for backwards compatibility with the other places it is used in the codebase. Ideally other parts of the codebase would be improved with generator functions as well, since the amount of RAM saved means that SadTalker will be able to work with longer videos and run much faster; this PR is just a first step.

Some background on why this was implemented:
The linux kernel was terminating the process when running the demo notebook on a 2.5min audio file with a 800x1199px image. I found that this was because >25GB of RAM were being allocated during the face_enhancer function call because of all of the images being stored in one list (unencoded videos are huge). By using the generator instead, less than 0.5GB of RAM were needed for face_enhancer and the notebook finished successfully.