### PR TITLE
Bug: Fixed bug that required old numpy. Updated numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.23.4
+numpy==1.24.3
 face_alignment==1.3.5
 imageio==2.19.3
 imageio-ffmpeg==0.4.7

--- a/src/face3d/util/preprocess.py
+++ b/src/face3d/util/preprocess.py
@@ -98,6 +98,6 @@ def align_img(img, lm, lm3D, mask=None, target_size=224., rescale_factor=102.):
 
     # processing the image
     img_new, lm_new, mask_new = resize_n_crop_img(img, lm, t, s, target_size=target_size, mask=mask)
-    trans_params = np.array([w0, h0, s, t[0], t[1]])
+    trans_params = np.array([w0, h0, s, t[0], t[1]], dtype=object)
 
     return trans_params, img_new, lm_new, mask_new


### PR DESCRIPTION
Error:
```
File "f:\Env\Lib\site-packages\sadTalksrc\face3d\util\preprocess.py", line 101, in align_img
    trans_params = np.array([w0, h0, s, t[0], t[1]])
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (5,) + inhomogeneous part.
```

Fix:
Adding ```dtype=object``` got over the error.