### PR TITLE
Fixed Python3.8 colab dependencies issue

### DIFF
--- a/quick_demo.ipynb
+++ b/quick_demo.ipynb
@@ -62,6 +62,8 @@
       "source": [
         "!update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.8 2  \n",
         "!update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.9 1  \n",
+        "!sudo apt install python3.8",
+        "!sudo apt-get install python3.8-distutils",
         "!python --version  \n",
         "!apt-get update\n",
         "!apt install software-properties-common\n",


### PR DESCRIPTION
These changes are must required to run this code on error free on colab, else resulting into error, because of distutils not found on colab.