### PR TITLE
Fix numpy 2.x compatibility: remove deprecated type aliases and fix scalar conversion

### DIFF
--- a/src/face3d/models/arcface_torch/eval_ijbc.py
+++ b/src/face3d/models/arcface_torch/eval_ijbc.py
@@ -120,8 +120,8 @@ def divideIntoNstrand(listTemp, n):
 def read_template_media_list(path):
     # ijb_meta = np.loadtxt(path, dtype=str)
     ijb_meta = pd.read_csv(path, sep=' ', header=None).values
-    templates = ijb_meta[:, 1].astype(np.int)
-    medias = ijb_meta[:, 2].astype(np.int)
+    templates = ijb_meta[:, 1].astype(np.int_)
+    medias = ijb_meta[:, 2].astype(np.int_)
     return templates, medias
 
 
@@ -132,10 +132,10 @@ def read_template_pair_list(path):
     # pairs = np.loadtxt(path, dtype=str)
     pairs = pd.read_csv(path, sep=' ', header=None).values
     # print(pairs.shape)
-    # print(pairs[:, 0].astype(np.int))
-    t1 = pairs[:, 0].astype(np.int)
-    t2 = pairs[:, 1].astype(np.int)
-    label = pairs[:, 2].astype(np.int)
+    # print(pairs[:, 0].astype(np.int_))
+    t1 = pairs[:, 0].astype(np.int_)
+    t2 = pairs[:, 1].astype(np.int_)
+    label = pairs[:, 2].astype(np.int_)
     return t1, t2, label
 
 

--- a/src/face3d/models/arcface_torch/onnx_ijbc.py
+++ b/src/face3d/models/arcface_torch/onnx_ijbc.py
@@ -77,16 +77,16 @@ def extract(model_root, dataset):
 
 def read_template_media_list(path):
     ijb_meta = pd.read_csv(path, sep=' ', header=None).values
-    templates = ijb_meta[:, 1].astype(np.int)
-    medias = ijb_meta[:, 2].astype(np.int)
+    templates = ijb_meta[:, 1].astype(np.int_)
+    medias = ijb_meta[:, 2].astype(np.int_)
     return templates, medias
 
 
 def read_template_pair_list(path):
     pairs = pd.read_csv(path, sep=' ', header=None).values
-    t1 = pairs[:, 0].astype(np.int)
-    t2 = pairs[:, 1].astype(np.int)
-    label = pairs[:, 2].astype(np.int)
+    t1 = pairs[:, 0].astype(np.int_)
+    t2 = pairs[:, 1].astype(np.int_)
+    label = pairs[:, 2].astype(np.int_)
     return t1, t2, label
 
 

--- a/src/face3d/models/arcface_torch/torch2onnx.py
+++ b/src/face3d/models/arcface_torch/torch2onnx.py
@@ -6,7 +6,7 @@ import torch
 def convert_onnx(net, path_module, output, opset=11, simplify=False):
     assert isinstance(net, torch.nn.Module)
     img = np.random.randint(0, 255, size=(112, 112, 3), dtype=np.int32)
-    img = img.astype(np.float)
+    img = img.astype(np.float64)
     img = (img / 255. - 0.5) / 0.5  # torch style norm
     img = img.transpose((2, 0, 1))
     img = torch.from_numpy(img).unsqueeze(0).float()

--- a/src/face3d/models/arcface_torch/utils/plot.py
+++ b/src/face3d/models/arcface_torch/utils/plot.py
@@ -18,9 +18,9 @@ files = [
 
 def read_template_pair_list(path):
     pairs = pd.read_csv(path, sep=' ', header=None).values
-    t1 = pairs[:, 0].astype(np.int)
-    t2 = pairs[:, 1].astype(np.int)
-    label = pairs[:, 2].astype(np.int)
+    t1 = pairs[:, 0].astype(np.int_)
+    t2 = pairs[:, 1].astype(np.int_)
+    label = pairs[:, 2].astype(np.int_)
     return t1, t2, label
 
 

--- a/src/face3d/util/my_awing_arch.py
+++ b/src/face3d/util/my_awing_arch.py
@@ -15,7 +15,7 @@ def calculate_points(heatmaps):
     indexes = np.argmax(heatline, axis=2)
 
     preds = np.stack((indexes % W, indexes // W), axis=2)
-    preds = preds.astype(np.float, copy=False)
+    preds = preds.astype(np.float64, copy=False)
 
     inr = indexes.ravel()
 

--- a/src/face3d/util/preprocess.py
+++ b/src/face3d/util/preprocess.py
@@ -9,7 +9,7 @@ import os
 from skimage import transform as trans
 import torch
 import warnings
-warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning) 
+warnings.filterwarnings("ignore", category=DeprecationWarning) 
 warnings.filterwarnings("ignore", category=FutureWarning) 
 
 
@@ -41,11 +41,14 @@ def POS(xp, x):
 # resize and crop images for face reconstruction
 def resize_n_crop_img(img, lm, t, s, target_size=224., mask=None):
     w0, h0 = img.size
-    w = (w0*s).astype(np.int32)
-    h = (h0*s).astype(np.int32)
-    left = (w/2 - target_size/2 + float((t[0] - w0/2)*s)).astype(np.int32)
+    s = float(np.squeeze(s))
+    t0 = float(np.squeeze(t[0]))
+    t1 = float(np.squeeze(t[1]))
+    w = int(w0 * s)
+    h = int(h0 * s)
+    left = int(w/2 - target_size/2 + (t0 - w0/2)*s)
     right = left + target_size
-    up = (h/2 - target_size/2 + float((h0/2 - t[1])*s)).astype(np.int32)
+    up = int(h/2 - target_size/2 + (h0/2 - t1)*s)
     below = up + target_size
 
     img = img.resize((w, h), resample=Image.BICUBIC)
@@ -55,8 +58,8 @@ def resize_n_crop_img(img, lm, t, s, target_size=224., mask=None):
         mask = mask.resize((w, h), resample=Image.BICUBIC)
         mask = mask.crop((left, up, right, below))
 
-    lm = np.stack([lm[:, 0] - t[0] + w0/2, lm[:, 1] -
-                  t[1] + h0/2], axis=1)*s
+    lm = np.stack([lm[:, 0] - t0 + w0/2, lm[:, 1] -
+                  t1 + h0/2], axis=1)*s
     lm = lm - np.reshape(
             np.array([(w/2 - target_size/2), (h/2-target_size/2)]), [1, 2])
 
@@ -98,6 +101,6 @@ def align_img(img, lm, lm3D, mask=None, target_size=224., rescale_factor=102.):
 
     # processing the image
     img_new, lm_new, mask_new = resize_n_crop_img(img, lm, t, s, target_size=target_size, mask=mask)
-    trans_params = np.array([w0, h0, s, t[0], t[1]])
+    trans_params = np.array([w0, h0, float(np.squeeze(s)), float(np.squeeze(t[0])), float(np.squeeze(t[1]))])
 
     return trans_params, img_new, lm_new, mask_new

--- a/src/utils/preprocess.py
+++ b/src/utils/preprocess.py
@@ -145,7 +145,7 @@ class CropAndExtract():
 
                 trans_params, im1, lm1, _ = align_img(frame, lm1, self.lm3d_std)
  
-                trans_params = np.array([float(item) for item in np.hsplit(trans_params, 5)]).astype(np.float32)
+                trans_params = np.array([item.item() for item in np.hsplit(trans_params, 5)]).astype(np.float32)
                 im_t = torch.tensor(np.array(im1)/255., dtype=torch.float32).permute(2, 0, 1).to(self.device).unsqueeze(0)
                 
                 with torch.no_grad():


### PR DESCRIPTION
## Summary

numpy 2.0 made two breaking changes that crash SadTalker on import and during inference:

1. **Removed deprecated scalar-type aliases** - `np.float`, `np.int`, `np.bool`, `np.complex`, `np.object`, `np.str` are gone.
2. **Tightened `float()` / `int()` conversion** - these now only accept 0-dimensional arrays; passing a 1-element 1-D array raises `TypeError: only 0-dimensional arrays can be converted to Python scalars`.

## Files changed

| File | Change |
|------|--------|
| `src/face3d/util/my_awing_arch.py` | `np.float` ? `np.float64` |
| `src/face3d/models/arcface_torch/torch2onnx.py` | `np.float` ? `np.float64` |
| `src/face3d/models/arcface_torch/eval_ijbc.py` | `np.int` ? `np.int_` (x4) |
| `src/face3d/models/arcface_torch/onnx_ijbc.py` | `np.int` ? `np.int_` (x4) |
| `src/face3d/models/arcface_torch/utils/plot.py` | `np.int` ? `np.int_` (x3) |
| `src/face3d/util/preprocess.py` | Fix `np.VisibleDeprecationWarning`; extract scalar s/t via `np.squeeze()` before `int()` in `resize_n_crop_img`; wrap t/s in `float(np.squeeze(...))` in `align_img` |
| `src/utils/preprocess.py` | Replace `float(item)` with `item.item()` for `np.hsplit` results in `CropAndExtract` |

## Testing

Verified end-to-end with:
```
python inference.py --driven_audio test.wav --source_image avatar.jpg --result_dir output/ --still --preprocess full --size 256 --cpu
```
Environment: Python 3.14, numpy 2.4.6, torch 2.12.0+cpu, Windows 11.